### PR TITLE
Hotfix: Encoder Parsing

### DIFF
--- a/src/wroboclaw/roboclaw/serial_interface.py
+++ b/src/wroboclaw/roboclaw/serial_interface.py
@@ -60,7 +60,7 @@ class SerialCommandHandler:
         """
         try:
             data = self._param_struct.pack(*args)
-            csum = STRUCT_CRC16.pack(crc16(data, initial=self._header_csum) & 0xFFFF)
+            csum = STRUCT_CRC16.pack(crc16(data, initial=self._header_csum))
             self._serial.write(self._header)
             self._serial.write(data)
             self._serial.write(csum)
@@ -109,7 +109,7 @@ class SerialRequestHandler:
             data = self._serial.read(self._res_struct.size)
             if len(data) != self._res_struct.size:
                 return None
-            csum = crc16(data[:-2], initial=self._header_csum) & 0xFFFF
+            csum = crc16(data[:-2], initial=self._header_csum)
             res = self._res_struct.unpack(data)
             return res[:-1] if res[-1] == csum else None
         except SerialException:

--- a/src/wroboclaw/util/checksum.py
+++ b/src/wroboclaw/util/checksum.py
@@ -24,4 +24,4 @@ def crc16(*datas: Iterable[int], initial: int = 0) -> int:
                     csum = (csum << 1) ^ 0x1021
                 else:
                     csum <<= 1
-    return csum
+    return csum & 0xFFFF


### PR DESCRIPTION
Changes:
* Updating the single encoder read format to capture (but not use, as of now) a status word, as defined for instructions 16 and 17 for Roboclaw Advanced Packet Serial operation (pg. 86-87, [roboclaw_user_manual.pdf](https://downloads.basicmicro.com/docs/roboclaw_user_manual.pdf))
* Moving the enforcement of the 16 bit length of the CRC16 to the `crc16` method