### PR TITLE
Report Watchdog Stop

### DIFF
--- a/nodes/drive_roboclaw.py
+++ b/nodes/drive_roboclaw.py
@@ -137,7 +137,7 @@ class ClawInst:
         """Logging Publication"""
         if self.claw.get_watchdog_stop():
             self._publishing_stop = True
-            rospy.logwarn_throttle(rospy.Time.from_sec(5), f"Watchdog stop engaged on address 0x{self.claw.address:x}")
+            rospy.logwarn_throttle(rospy.Time.from_sec(5), f"Watchdog stop engaged on address 0x{self.claw_def.address:x}")
         elif self._publishing_stop:
             self._publishing_stop = False
             rospy.loginfo(f"Watchdog stop disengaged on {self.claw_def.address:x}, driving motors...")

--- a/nodes/drive_roboclaw.py
+++ b/nodes/drive_roboclaw.py
@@ -138,7 +138,7 @@ class ClawInst:
         if self.claw.get_watchdog_stop() and not self._publishing_stop:
             self._publishing_stop = True
             rospy.logwarn(f"Watchdog stop engaged on address 0x{self.claw_def.address:x}")
-        elif self._publishing_stop:
+        elif not self.claw.get_watchdog_stop() and self._publishing_stop:
             self._publishing_stop = False
             rospy.loginfo(f"Watchdog stop disengaged on {self.claw_def.address:x}, driving motors...")
 

--- a/nodes/drive_roboclaw.py
+++ b/nodes/drive_roboclaw.py
@@ -137,7 +137,7 @@ class ClawInst:
         """Logging Publication"""
         if self.claw.get_watchdog_stop():
             self._publishing_stop = True
-            rospy.logwarn_throttle(rospy.Time.from_sec(5), f"Watchdog stop engaged on address 0x{self.claw_def.address:x}")
+            rospy.logwarn_throttle(5, f"Watchdog stop engaged on address 0x{self.claw_def.address:x}")
         elif self._publishing_stop:
             self._publishing_stop = False
             rospy.loginfo(f"Watchdog stop disengaged on {self.claw_def.address:x}, driving motors...")

--- a/nodes/drive_roboclaw.py
+++ b/nodes/drive_roboclaw.py
@@ -137,7 +137,7 @@ class ClawInst:
         """Logging Publication"""
         if self.claw.get_watchdog_stop() and not self._publishing_stop:
             self._publishing_stop = True
-            rospy.logwarn(5, f"Watchdog stop engaged on address 0x{self.claw_def.address:x}")
+            rospy.logwarn(f"Watchdog stop engaged on address 0x{self.claw_def.address:x}")
         elif self._publishing_stop:
             self._publishing_stop = False
             rospy.loginfo(f"Watchdog stop disengaged on {self.claw_def.address:x}, driving motors...")

--- a/nodes/drive_roboclaw.py
+++ b/nodes/drive_roboclaw.py
@@ -113,7 +113,7 @@ class ClawInst:
         self.over_curr_pub_l = rospy.Publisher(f'{self.claw_def.topic}/curr/over_lim/left', Bool, queue_size=10)
         self.over_curr_pub_r = rospy.Publisher(f'{self.claw_def.topic}/curr/over_lim/right', Bool, queue_size=10)
 
-        self._publishing_stop
+        self._publishing_stop = False
 
     def tick(self):
         """Ticks publications for this Roboclaw instance."""

--- a/nodes/drive_roboclaw.py
+++ b/nodes/drive_roboclaw.py
@@ -140,7 +140,7 @@ class ClawInst:
             rospy.logwarn_throttle(rospy.Time.from_sec(5), f"Watchdog stop engaged on address 0x{self.claw.address:x}")
         elif self._publishing_stop:
             self._publishing_stop = False
-            rospy.loginfo(f"Watchdog stop disengaged on {self.claw.address:x}, driving motors...")
+            rospy.loginfo(f"Watchdog stop disengaged on {self.claw_def.address:x}, driving motors...")
 
 def main():
     """A driver node for Roboclaws.

--- a/nodes/drive_roboclaw.py
+++ b/nodes/drive_roboclaw.py
@@ -140,7 +140,7 @@ class ClawInst:
             rospy.logwarn(f"Watchdog stop engaged on address 0x{self.claw_def.address:x}")
         elif not self.claw.get_watchdog_stop() and self._publishing_stop:
             self._publishing_stop = False
-            rospy.loginfo(f"Watchdog stop disengaged on {self.claw_def.address:x}, driving motors...")
+            rospy.loginfo(f"Watchdog stop disengaged on 0x{self.claw_def.address:x}, driving motors...")
 
 def main():
     """A driver node for Roboclaws.

--- a/nodes/drive_roboclaw.py
+++ b/nodes/drive_roboclaw.py
@@ -137,7 +137,7 @@ class ClawInst:
         """Logging Publication"""
         if self.claw.get_watchdog_stop():
             self._publishing_stop = True
-            rospy.logwarn_throttle(5, f"Watchdog stop engaged on address 0x{self.claw_def.address:x}")
+            rospy.logwarn_throttle_identical(5, f"Watchdog stop engaged on address 0x{self.claw_def.address:x}")
         elif self._publishing_stop:
             self._publishing_stop = False
             rospy.loginfo(f"Watchdog stop disengaged on {self.claw_def.address:x}, driving motors...")

--- a/nodes/drive_roboclaw.py
+++ b/nodes/drive_roboclaw.py
@@ -135,9 +135,9 @@ class ClawInst:
             self.over_curr_pub_r.publish(Bool(over_curr_lim_r))
 
         """Logging Publication"""
-        if self.claw.get_watchdog_stop():
+        if self.claw.get_watchdog_stop() and not self._publishing_stop:
             self._publishing_stop = True
-            rospy.logwarn_throttle_identical(5, f"Watchdog stop engaged on address 0x{self.claw_def.address:x}")
+            rospy.logwarn(5, f"Watchdog stop engaged on address 0x{self.claw_def.address:x}")
         elif self._publishing_stop:
             self._publishing_stop = False
             rospy.loginfo(f"Watchdog stop disengaged on {self.claw_def.address:x}, driving motors...")

--- a/src/wroboclaw/roboclaw/mock.py
+++ b/src/wroboclaw/roboclaw/mock.py
@@ -41,6 +41,9 @@ class RoboclawMock(Roboclaw):
     def get_over_current_status(self) -> Tuple[Optional[bool], Optional[bool]]:
         return False, False # no current draw in mock motors
 
+    def get_watchdog_stop(self) -> bool:
+        return False # no watchdog, can't be engaged
+
 class RoboclawChainMock(RoboclawChain, RoboclawChainApi):
     """A mock Roboclaw chain that provides simulated Roboclaws."""
     

--- a/src/wroboclaw/roboclaw/model.py
+++ b/src/wroboclaw/roboclaw/model.py
@@ -114,6 +114,15 @@ class Roboclaw(ABC):
         """
         raise NotImplementedError('Abstract method!')
 
+    @abstractmethod
+    def get_watchdog_stop(self) -> bool:
+        """Gets whether or note the watchdog stop is engaged
+
+        Returns:
+            bool: Whether or not the watchdog stop is engaged
+        """
+        raise NotImplementedError('AbstractMethod')
+
 class RoboclawChainApi(ABC):
     """Allows for extracting individual Roboclaw instances from a chain."""
     

--- a/src/wroboclaw/roboclaw/serial_interface.py
+++ b/src/wroboclaw/roboclaw/serial_interface.py
@@ -231,6 +231,7 @@ class RoboclawSerialInstance(Roboclaw):
 
             # write motors
             if self._watchdog.check():
+                self._watchdog_stop_engaged = False
                 if self._sent_spd_l != self._target_spd_l:
                     if self._sent_spd_r != self._target_spd_r:
                         if self._cmd_mixed_duty.invoke(self._target_spd_l, self._target_spd_r):

--- a/src/wroboclaw/roboclaw/serial_interface.py
+++ b/src/wroboclaw/roboclaw/serial_interface.py
@@ -3,9 +3,6 @@ from struct import Struct
 from threading import Lock, Thread
 from typing import Any, Dict, List, Optional, Tuple
 
-# Use for logging, not for normal ROS comms
-from rospy import logwarn as ros_logwarn, loginfo as ros_loginfo
-
 from ..util.checksum import crc16
 from ..util.watchdog import SimpleWatchdog
 from .model import Roboclaw, RoboclawChain, RoboclawChainApi

--- a/src/wroboclaw/roboclaw/serial_interface.py
+++ b/src/wroboclaw/roboclaw/serial_interface.py
@@ -296,8 +296,7 @@ class RoboclawSerialApi(RoboclawChainApi):
         self._alive_claws = 0
         self._alive = True
         self._alive_lock = Lock()
-        self._comms_thread = Thread(
-            target=self._comms_loop, name=f'Roboclaw Comms: {serial.portstr}')
+        self._comms_thread = Thread(target=self._comms_loop, name=f'Roboclaw Comms: {serial.portstr}')
         self._comms_thread.start()
 
     def _comms_loop(self):
@@ -357,8 +356,7 @@ class RoboclawChainSerial(RoboclawChain):
         self._instance: Optional[RoboclawSerialApi] = None
 
     def __enter__(self) -> RoboclawChainApi:
-        self._instance = RoboclawSerialApi(
-            Serial(self.com_port, self.baud, timeout=self.timeout))
+        self._instance = RoboclawSerialApi(Serial(self.com_port, self.baud, timeout=self.timeout))
         return self._instance
 
     def __exit__(self, e_type, value, traceback):

--- a/src/wroboclaw/roboclaw/serial_interface.py
+++ b/src/wroboclaw/roboclaw/serial_interface.py
@@ -162,6 +162,9 @@ class RoboclawSerialInstance(Roboclaw):
         self._req_get_mixed_enc = SerialRequestHandler(serial, address, 78, STRUCT_MIXED_ENC_CNT)
         self._req_get_mixed_current = SerialRequestHandler(serial, address, 49, STRUCT_MIXED_CURRENT)
 
+        self._address = address
+        self._watchdog_stop_engaged = False
+
         self._alive = True
         self._state_lock = Lock()
 


### PR DESCRIPTION
This enables ROS logging whenever the Watchdog stop on a Roboclaw is engaged/disengaged.

It also reformats some things based on what AutoPEP8 thought was good before I disabled it.