### PR TITLE
Feature/7 mock offset and counts per rotation support

### DIFF
--- a/nodes/drive_roboclaw.py
+++ b/nodes/drive_roboclaw.py
@@ -9,8 +9,7 @@ from std_msgs.msg import Int16, UInt32, Float32, Bool
 from wroboclaw.msg import Int16Pair
 from wroboclaw.roboclaw import init_roboclaw
 from wroboclaw.roboclaw.model import Roboclaw, RoboclawChainApi
-
-UINT32_MAX = (1 << 32) - 1
+from wroboclaw.roboclaw.mock import UINT32_BOUNDS
 
 class ClawDef:
     """A single Roboclaw definition."""
@@ -57,8 +56,8 @@ class ClawDef:
         self.curr_lim_l = dto.get('current_limit_left', None)
         self.curr_lim_r = dto.get('current_limit_right', None)
 
-        self.counts_per_rotation_l, self.offset_l = (enc_l.get('counts_per_rotation', None), enc_l.get('offset', None)) if enc_l else (UINT32_MAX, 0)
-        self.counts_per_rotation_r, self.offset_r = (enc_r.get('counts_per_rotation', None), enc_r.get('offset', None)) if enc_r else (UINT32_MAX, 0)
+        self.counts_per_rotation_l, self.offset_l = (enc_l.get('counts_per_rotation', None), enc_l.get('offset', None)) if enc_l else (UINT32_BOUNDS[1], 0)
+        self.counts_per_rotation_r, self.offset_r = (enc_r.get('counts_per_rotation', None), enc_r.get('offset', None)) if enc_r else (UINT32_BOUNDS[1], 0)
 
     def init_claw(self, claw_chain: RoboclawChainApi) -> Roboclaw:
         """Initializes a Roboclaw instance as defined by this definition.
@@ -185,7 +184,6 @@ def main():
     timeout = rospy.get_param('~timeout', 0.01)
     mock = rospy.get_param('~mock', False)
     claw_defs_dto = cast(Dict[str, Dict[str, Any]], rospy.get_param('~claws'))
-    print(claw_defs_dto)
 
     # parse out roboclaw definitions
     claw_defs = [ClawDef(name, dto) for name, dto in claw_defs_dto.items()]

--- a/nodes/drive_roboclaw.py
+++ b/nodes/drive_roboclaw.py
@@ -9,7 +9,7 @@ from std_msgs.msg import Int16, UInt32, Float32, Bool
 from wroboclaw.msg import Int16Pair
 from wroboclaw.roboclaw import init_roboclaw
 from wroboclaw.roboclaw.model import Roboclaw, RoboclawChainApi
-from wroboclaw.roboclaw.mock import UINT32_BOUNDS
+from wroboclaw.util.util import UINT32_BOUNDS
 
 class ClawDef:
     """A single Roboclaw definition."""

--- a/src/wroboclaw/roboclaw/mock.py
+++ b/src/wroboclaw/roboclaw/mock.py
@@ -43,15 +43,15 @@ class RoboclawMock(Roboclaw):
 
     def set_counts_per_rotation(self, counts_per_rotation_l : int = None, counts_per_rotation_r : int = None) -> None:
         if counts_per_rotation_l is not None:
-            self._left._set_counts_per_rotation(counts_per_rotation_l)
+            self._left.set_counts_per_rotation(counts_per_rotation_l)
         if counts_per_rotation_r is not None:
-            self._right._set_counts_per_rotation(counts_per_rotation_r)
+            self._right.set_counts_per_rotation(counts_per_rotation_r)
 
     def set_offset(self, offset_l : int = None, offset_r : int = None) -> None:
         if offset_l is not None:
-            self._left._set_offset(offset_l)
+            self._left.set_offset(offset_l)
         if offset_r is not None:
-            self._right._set_offset(offset_r)
+            self._right.set_offset(offset_r)
 
 class RoboclawChainMock(RoboclawChain, RoboclawChainApi):
     """A mock Roboclaw chain that provides simulated Roboclaws."""

--- a/src/wroboclaw/roboclaw/mock.py
+++ b/src/wroboclaw/roboclaw/mock.py
@@ -43,9 +43,9 @@ class RoboclawMock(Roboclaw):
 
     def set_counts_per_rotation(self, counts_per_rotation_l : int = None, counts_per_rotation_r : int = None) -> None:
         if counts_per_rotation_l is not None:
-            self._left = MockVelCtrl((0, counts_per_rotation_l), BoundaryBehaviour.wrap)
+            self._left._set_counts_per_rotation(counts_per_rotation_l)
         if counts_per_rotation_r is not None:
-            self._right = MockVelCtrl((0, counts_per_rotation_r), BoundaryBehaviour.wrap)
+            self._right._set_counts_per_rotation(counts_per_rotation_r)
 
     def set_offset(self, offset_l : int = None, offset_r : int = None) -> None:
         if offset_l is not None:

--- a/src/wroboclaw/roboclaw/mock.py
+++ b/src/wroboclaw/roboclaw/mock.py
@@ -41,6 +41,18 @@ class RoboclawMock(Roboclaw):
     def get_over_current_status(self) -> Tuple[Optional[bool], Optional[bool]]:
         return False, False # no current draw in mock motors
 
+    def set_counts_per_rotation(self, counts_per_rotation_l : int = None, counts_per_rotation_r : int = None) -> None:
+        if counts_per_rotation_l is not None:
+            self._left = MockVelCtrl((0, counts_per_rotation_l), BoundaryBehaviour.wrap)
+        if counts_per_rotation_r is not None:
+            self._right = MockVelCtrl((0, counts_per_rotation_r), BoundaryBehaviour.wrap)
+
+    def set_offset(self, offset_l : int = None, offset_r : int = None) -> None:
+        if offset_l is not None:
+            self._left._set_offset(offset_l)
+        if offset_r is not None:
+            self._right._set_offset(offset_r)
+
 class RoboclawChainMock(RoboclawChain, RoboclawChainApi):
     """A mock Roboclaw chain that provides simulated Roboclaws."""
     

--- a/src/wroboclaw/roboclaw/mock.py
+++ b/src/wroboclaw/roboclaw/mock.py
@@ -2,11 +2,8 @@ from collections import defaultdict
 from typing import DefaultDict, Optional, Tuple
 
 from ..util.mock import MockVelCtrl
-from ..util.util import BoundaryBehaviour
+from ..util.util import BoundaryBehaviour, UINT32_BOUNDS, INT16_MAX
 from .model import Roboclaw, RoboclawChain, RoboclawChainApi        
-
-UINT32_BOUNDS = (0, (1 << 32) - 1)
-INT16_MAX = (1 << 15) - 1
 
 class RoboclawMock(Roboclaw):
     """A mock Roboclaw that uses simulated motors to produce mock data."""

--- a/src/wroboclaw/roboclaw/model.py
+++ b/src/wroboclaw/roboclaw/model.py
@@ -114,6 +114,32 @@ class Roboclaw(ABC):
         """
         raise NotImplementedError('Abstract method!')
 
+    @abstractmethod
+    def set_counts_per_rotation(self, counts_per_rotation_l : int = None, counts_per_rotation_r : int = None) -> None:
+        """Sets the counts per rotation for a given encoder
+
+        Parameters
+        ----------
+        counts_per_rotation_l : int
+            Counts per rotation for the left encoder
+        counts_per_rotation_r : int
+            Counts per rotation for the right encoder
+        """
+        raise NotImplementedError('Abstract method!')
+
+    @abstractmethod
+    def set_offset(self, offset_l : int = None, offset_r : int = None) -> None:
+        """Sets the offset for a given encoder
+
+        Parameters
+        ----------
+        offset_l : int
+            The offset for the left encoder
+        offset_r : int
+            The offset for the right encoder
+        """
+        raise NotImplementedError('Abstract method!')
+
 class RoboclawChainApi(ABC):
     """Allows for extracting individual Roboclaw instances from a chain."""
     

--- a/src/wroboclaw/roboclaw/model.py
+++ b/src/wroboclaw/roboclaw/model.py
@@ -115,7 +115,6 @@ class Roboclaw(ABC):
         raise NotImplementedError('Abstract method!')
 
     @abstractmethod
-<<<<<<< HEAD
     def set_counts_per_rotation(self, counts_per_rotation_l : int = None, counts_per_rotation_r : int = None) -> None:
         """Sets the counts per rotation for a given encoder
 
@@ -140,7 +139,6 @@ class Roboclaw(ABC):
             The offset for the right encoder
         """
         raise NotImplementedError('Abstract method!')
-=======
     def get_watchdog_stop(self) -> bool:
         """Gets whether or note the watchdog stop is engaged
 
@@ -148,7 +146,6 @@ class Roboclaw(ABC):
             bool: Whether or not the watchdog stop is engaged
         """
         raise NotImplementedError('AbstractMethod')
->>>>>>> cfb3a2593eed0bbf6094eb01b4b08998b69d2f97
 
 class RoboclawChainApi(ABC):
     """Allows for extracting individual Roboclaw instances from a chain."""

--- a/src/wroboclaw/roboclaw/serial_interface.py
+++ b/src/wroboclaw/roboclaw/serial_interface.py
@@ -207,17 +207,14 @@ class RoboclawSerialInstance(Roboclaw):
             return self._curr_l > self._curr_lim_l if self._curr_lim_l is not None else None, \
                 self._curr_r > self._curr_lim_r if self._curr_lim_r is not None else None
 
-<<<<<<< HEAD
     def set_counts_per_rotation(self, counts_per_rotation_l : int = None, counts_per_rotation_r : int = None) -> None:
         pass #Implementation unneeded because for the real roboclaw, encoder values will be read from hardware
 
     def set_offset(self, offset_l : int = None, offset_r : int = None) -> None:
         pass #Implementation unneeded because for the real roboclaw, encoder values will be read from hardware
-=======
     def get_watchdog_stop(self) -> bool:
         with self._state_lock:
             return self._watchdog_stop_engaged
->>>>>>> cfb3a2593eed0bbf6094eb01b4b08998b69d2f97
 
     def _tick(self) -> bool: # TODO serial invocations ignore errors; maybe handle them
         """Updates this Roboclaw's state, taking control of the UART port for the duration.

--- a/src/wroboclaw/roboclaw/serial_interface.py
+++ b/src/wroboclaw/roboclaw/serial_interface.py
@@ -199,10 +199,10 @@ class RoboclawSerialInstance(Roboclaw):
                 self._curr_r > self._curr_lim_r if self._curr_lim_r is not None else None
 
     def set_counts_per_rotation(self, counts_per_rotation_l : int = None, counts_per_rotation_r : int = None) -> None:
-        pass
+        pass #Implementation unneeded because for the real roboclaw, encoder values will be read from hardware
 
     def set_offset(self, offset_l : int = None, offset_r : int = None) -> None:
-        pass
+        pass #Implementation unneeded because for the real roboclaw, encoder values will be read from hardware
 
     def _tick(self) -> bool: # TODO serial invocations ignore errors; maybe handle them
         """Updates this Roboclaw's state, taking control of the UART port for the duration.

--- a/src/wroboclaw/roboclaw/serial_interface.py
+++ b/src/wroboclaw/roboclaw/serial_interface.py
@@ -198,6 +198,12 @@ class RoboclawSerialInstance(Roboclaw):
             return self._curr_l > self._curr_lim_l if self._curr_lim_l is not None else None, \
                 self._curr_r > self._curr_lim_r if self._curr_lim_r is not None else None
 
+    def set_counts_per_rotation(self, counts_per_rotation_l : int = None, counts_per_rotation_r : int = None) -> None:
+        pass
+
+    def set_offset(self, offset_l : int = None, offset_r : int = None) -> None:
+        pass
+
     def _tick(self) -> bool: # TODO serial invocations ignore errors; maybe handle them
         """Updates this Roboclaw's state, taking control of the UART port for the duration.
         

--- a/src/wroboclaw/util/mock.py
+++ b/src/wroboclaw/util/mock.py
@@ -31,7 +31,7 @@ class MockVelCtrl():
             self._current_pos = boundary_clamp(self.pos_clamp, self._current_pos, *self.pos_bounds)
         self._last_update_time = now
 
-    def _set_offset(self, offset: int):
+    def set_offset(self, offset: int):
         """Sets an offset for the current encoder. Intended to be called before the motor starts
         
         Parameters
@@ -41,7 +41,7 @@ class MockVelCtrl():
         """
         self._current_pos = offset
 
-    def _set_counts_per_rotation(self, counts_per_rotation: int):
+    def set_counts_per_rotation(self, counts_per_rotation: int):
         """Sets a value for the counts per rotation for the current encoder. Also intended to be called before the motor starts
         
         Parameters

--- a/src/wroboclaw/util/mock.py
+++ b/src/wroboclaw/util/mock.py
@@ -31,6 +31,16 @@ class MockVelCtrl():
             self._current_pos = boundary_clamp(self.pos_clamp, self._current_pos, *self.pos_bounds)
         self._last_update_time = now
 
+    def _set_offset(self, offset: int):
+        """Sets an offset for the current encoder. Intended to be called before the motor starts
+        
+        Parameters
+        ----------
+        offset : int
+            The offset to be set for this encoder
+        """
+        self._current_pos = offset
+
     def set_velocity(self, vel: float):
         """Changes the velocity of the motor.
 

--- a/src/wroboclaw/util/mock.py
+++ b/src/wroboclaw/util/mock.py
@@ -41,6 +41,16 @@ class MockVelCtrl():
         """
         self._current_pos = offset
 
+    def _set_counts_per_rotation(self, counts_per_rotation: int):
+        """Sets a value for the counts per rotation for the current encoder. Also intended to be called before the motor starts
+        
+        Parameters
+        ----------
+        counts_per_rotation: int
+            The counts per rotation for this encoder
+        """
+        self.pos_bounds = (0, counts_per_rotation)
+
     def set_velocity(self, vel: float):
         """Changes the velocity of the motor.
 

--- a/src/wroboclaw/util/util.py
+++ b/src/wroboclaw/util/util.py
@@ -1,5 +1,8 @@
 from enum import Enum
 
+UINT32_BOUNDS = (0, (1 << 32) - 1)
+INT16_MAX = (1 << 15) - 1
+
 class BoundaryBehaviour(Enum):
     """Describes some behaviour for clamping a value to an interval."""
     wrap = 0


### PR DESCRIPTION
Added support for setting counts per rotation and offsets for roboclaws. The real roboclaws will just read from the hardware but the mock ones will be able to read from a file, which will include the parameters. Important to note: Only the logic to do this has been implemented so far, I have not modified the parameter file. [Fixed issue #7]